### PR TITLE
Add item management page

### DIFF
--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -3,21 +3,26 @@
 // app/Http/Controllers/ItemController.php
 namespace App\Http\Controllers;
 
-use App\Models\Item;
+use App\Models\{Category, Item};
 use Illuminate\Http\Request;
 
 class ItemController extends Controller {
     public function index(){
-        return view('items.index', ['items'=>Item::with('category')->paginate(20)]);
+        return view('items.index', [
+            'items'=>Item::with('category')->paginate(20),
+            'categories'=>Category::all(),
+        ]);
     }
     public function store(Request $r){
         $data = $r->validate([
             'barcode'=>'required|unique:items,barcode',
             'name'=>'required',
+            'serial_number'=>'nullable',
+            'procurement_year'=>'nullable|integer|min:1900|max:'.date('Y'),
+            'details'=>'nullable',
             'category_id'=>'required|exists:categories,id',
             'stock'=>'required|integer|min:0',
             'condition'=>'required|in:baik,rusak_ringan,rusak_berat',
-            'notes'=>'nullable'
         ]);
         Item::create($data);
         return back()->with('ok','Barang ditambahkan');

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -6,8 +6,17 @@ use Illuminate\Database\Eloquent\Model;
 
 class Item extends Model
 {
-    //
-    protected $fillable = ['barcode','name','category_id','stock','condition','notes'];
+    protected $fillable = [
+        'barcode',
+        'name',
+        'serial_number',
+        'procurement_year',
+        'details',
+        'category_id',
+        'stock',
+        'condition',
+    ];
+
     public function category(){ return $this->belongsTo(Category::class); }
     public function loanItems(){ return $this->hasMany(LoanItem::class); }
 }

--- a/database/migrations/2025_08_09_112718_create_items_table.php
+++ b/database/migrations/2025_08_09_112718_create_items_table.php
@@ -15,10 +15,12 @@ return new class extends Migration
             $table->id();
             $table->string('barcode')->unique();
             $table->string('name');
+            $table->string('serial_number')->nullable();
+            $table->unsignedSmallInteger('procurement_year')->nullable();
+            $table->text('details')->nullable();
             $table->foreignId('category_id')->constrained()->cascadeOnDelete();
             $table->unsignedInteger('stock')->default(0);
             $table->enum('condition', ['baik','rusak_ringan','rusak_berat'])->default('baik');
-            $table->text('notes')->nullable();
             $table->timestamps();
         });
     }

--- a/resources/views/items/index.blade.php
+++ b/resources/views/items/index.blade.php
@@ -1,0 +1,85 @@
+<!-- resources/views/items/index.blade.php -->
+@extends('layouts.app')
+@section('content')
+<h1 class="text-xl font-semibold mb-4">Master Barang</h1>
+
+<form action="{{ route('items.store') }}" method="post" class="grid md:grid-cols-2 gap-4 bg-white p-4 rounded-2xl shadow mb-4">
+    @csrf
+    <div>
+        <label class="block text-sm">Kode Barang</label>
+        <input name="barcode" class="w-full border rounded p-2" required>
+    </div>
+    <div>
+        <label class="block text-sm">Nama Barang</label>
+        <input name="name" class="w-full border rounded p-2" required>
+    </div>
+    <div>
+        <label class="block text-sm">Serial Number</label>
+        <input name="serial_number" class="w-full border rounded p-2">
+    </div>
+    <div>
+        <label class="block text-sm">Tahun Pengadaan</label>
+        <input type="number" name="procurement_year" min="1900" max="{{ date('Y') }}" class="w-full border rounded p-2">
+    </div>
+    <div class="md:col-span-2">
+        <label class="block text-sm">Detail Barang</label>
+        <textarea name="details" class="w-full border rounded p-2"></textarea>
+    </div>
+    <div>
+        <label class="block text-sm">Kategori</label>
+        <select name="category_id" class="w-full border rounded p-2" required>
+            <option value="">-- Pilih --</option>
+            @foreach($categories as $c)
+            <option value="{{ $c->id }}">{{ $c->name }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div>
+        <label class="block text-sm">Kondisi</label>
+        <select name="condition" class="w-full border rounded p-2" required>
+            <option value="baik">Baik</option>
+            <option value="rusak_ringan">Rusak Ringan</option>
+            <option value="rusak_berat">Rusak Berat</option>
+        </select>
+    </div>
+    <div>
+        <label class="block text-sm">Jumlah Stok</label>
+        <input type="number" name="stock" min="0" class="w-full border rounded p-2" required>
+    </div>
+    <div class="md:col-span-2 text-right">
+        <button class="px-4 py-2 rounded bg-slate-800 text-white">Simpan</button>
+    </div>
+</form>
+
+<div class="bg-white rounded-2xl shadow overflow-auto">
+    <table class="w-full text-sm">
+        <thead class="bg-slate-100">
+            <tr>
+                <th class="p-2 text-left">Kode</th>
+                <th class="p-2 text-left">Nama</th>
+                <th class="p-2 text-left">Serial</th>
+                <th class="p-2 text-left">Tahun</th>
+                <th class="p-2 text-left">Detail</th>
+                <th class="p-2 text-left">Kategori</th>
+                <th class="p-2 text-left">Kondisi</th>
+                <th class="p-2 text-center">Stok</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($items as $it)
+            <tr class="border-t">
+                <td class="p-2">{{ $it->barcode }}</td>
+                <td class="p-2">{{ $it->name }}</td>
+                <td class="p-2">{{ $it->serial_number }}</td>
+                <td class="p-2">{{ $it->procurement_year }}</td>
+                <td class="p-2">{{ $it->details }}</td>
+                <td class="p-2">{{ $it->category->name }}</td>
+                <td class="p-2">{{ str_replace('_',' ',$it->condition) }}</td>
+                <td class="p-2 text-center">{{ $it->stock }}</td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>
+<div class="mt-3">{{ $items->links() }}</div>
+@endsection

--- a/tests/Feature/ItemManagementTest.php
+++ b/tests/Feature/ItemManagementTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Category;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ItemManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_item_can_be_created(): void
+    {
+        $category = Category::create(['name' => 'Elektronik']);
+
+        $response = $this->post('/items', [
+            'barcode' => 'BRG001',
+            'name' => 'Kamera',
+            'serial_number' => 'SN123',
+            'procurement_year' => 2024,
+            'details' => 'DSLR',
+            'category_id' => $category->id,
+            'stock' => 5,
+            'condition' => 'baik',
+        ]);
+
+        $response->assertSessionHas('ok', 'Barang ditambahkan');
+        $this->assertDatabaseHas('items', [
+            'barcode' => 'BRG001',
+            'serial_number' => 'SN123',
+            'procurement_year' => 2024,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add item management view with form and table
- track serial number, procurement year and details for items
- cover item creation with a feature test

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68ad4e0621b08325b8da7693049b137d