### PR TITLE
feat: add item management

### DIFF
--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -2,11 +2,43 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Item;
+use App\Models\{Item, Category};
 use Illuminate\Http\Request;
 
 class ItemController extends Controller
 {
+    public function index()
+    {
+        $items = Item::with('assets')->latest()->paginate(10);
+        $categories = Category::all();
+        return view('items.index', compact('items', 'categories'));
+    }
+
+    public function store(Request $r)
+    {
+        $data = $r->validate([
+            'name' => 'required',
+            'details' => 'nullable',
+            'category_id' => 'required|exists:categories,id',
+            'serial_number' => 'nullable',
+            'procurement_year' => 'nullable|integer',
+            'condition' => 'required|in:baik,rusak_ringan,rusak_berat',
+        ]);
+
+        $item = Item::firstOrCreate(
+            ['name' => $data['name'], 'category_id' => $data['category_id']],
+            ['details' => $data['details'] ?? null],
+        );
+
+        $item->assets()->create([
+            'serial_number' => $data['serial_number'] ?? null,
+            'procurement_year' => $data['procurement_year'] ?? null,
+            'condition' => $data['condition'],
+        ]);
+
+        return redirect()->route('items.index')->with('ok', 'Barang berhasil disimpan');
+    }
+
     // endpoint JSON untuk scan / pencarian
     public function search(Request $r)
     {

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\Item;
 
 class Asset extends Model
 {
@@ -18,5 +19,16 @@ class Asset extends Model
     public function item(): BelongsTo
     {
         return $this->belongsTo(Item::class);
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function (Asset $asset) {
+            if (!$asset->code) {
+                $item = Item::find($asset->item_id);
+                $count = $item->assets()->count() + 1;
+                $asset->code = $item->code . '-' . str_pad($count, 3, '0', STR_PAD_LEFT);
+            }
+        });
     }
 }

--- a/resources/views/items/index.blade.php
+++ b/resources/views/items/index.blade.php
@@ -13,6 +13,22 @@
         <label class="block text-sm">Detail Barang</label>
         <textarea name="details" class="w-full border rounded p-2"></textarea>
     </div>
+    <div>
+        <label class="block text-sm">Serial Number</label>
+        <input name="serial_number" class="w-full border rounded p-2">
+    </div>
+    <div>
+        <label class="block text-sm">Tahun Pengadaan</label>
+        <input type="number" name="procurement_year" class="w-full border rounded p-2">
+    </div>
+    <div>
+        <label class="block text-sm">Kondisi</label>
+        <select name="condition" class="w-full border rounded p-2" required>
+            <option value="baik">baik</option>
+            <option value="rusak_ringan">rusak ringan</option>
+            <option value="rusak_berat">rusak berat</option>
+        </select>
+    </div>
     <div class="md:col-span-2">
         <label class="block text-sm">Kategori</label>
         <select name="category_id" class="w-full border rounded p-2" required>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', fn() => redirect()->route('loans.index'));
 
 // Route::middleware(['web','auth'])->group(function(){
+    Route::get('/items', [ItemController::class,'index'])->name('items.index');
+    Route::post('/items', [ItemController::class,'store'])->name('items.store');
     Route::get('/items/search', [ItemController::class,'search'])->name('items.search'); // JSON
 
     // Loans

--- a/tests/Feature/ItemManagementTest.php
+++ b/tests/Feature/ItemManagementTest.php
@@ -19,7 +19,6 @@ class ItemManagementTest extends TestCase
             'category_id' => $category->id,
         ]);
         $item->assets()->create([
-            'code' => $item->code.'-001',
             'serial_number' => 'SN123',
             'procurement_year' => 2024,
             'condition' => 'baik',
@@ -30,6 +29,29 @@ class ItemManagementTest extends TestCase
             'code' => $item->code,
             'name' => 'Kamera',
             'stock' => 1,
+        ]);
+    }
+
+    public function test_store_creates_item_and_asset_with_generated_codes(): void
+    {
+        $category = Category::create(['name' => 'Elektronik']);
+        $response = $this->post('/items', [
+            'name' => 'Kamera',
+            'details' => 'DSLR',
+            'category_id' => $category->id,
+            'serial_number' => 'SN123',
+            'procurement_year' => 2024,
+            'condition' => 'baik',
+        ]);
+
+        $response->assertRedirect('/items');
+        $this->assertDatabaseHas('items', [
+            'name' => 'Kamera',
+            'code' => 'ELE001',
+        ]);
+        $this->assertDatabaseHas('assets', [
+            'serial_number' => 'SN123',
+            'code' => 'ELE001-001',
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- add item listing and creation page
- auto-generate asset codes based on item and category
- cover item management with tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68adcae42cd883259f10b65d21cfba09