### PR TITLE
Add category code field and update item code generation

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -17,6 +17,7 @@ class CategoryController extends Controller
     {
         $data = $r->validate([
             'name' => 'required|unique:categories,name',
+            'code' => 'required|unique:categories,code',
         ]);
 
         Category::create($data);

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -6,6 +6,14 @@ use Illuminate\Database\Eloquent\Model;
 
 class Category extends Model
 {
-    protected $fillable = ['name'];
+    protected $fillable = ['name','code'];
+
     public function items(){ return $this->hasMany(Item::class); }
+
+    protected static function booted(): void
+    {
+        static::saving(function (Category $category) {
+            $category->code = strtoupper($category->code);
+        });
+    }
 }

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -28,7 +28,7 @@ class Item extends Model
     {
         static::creating(function (Item $item) {
             $category = Category::find($item->category_id);
-            $prefix = strtoupper(substr($category->name, 0, 3));
+            $prefix = strtoupper($category->code);
             $count = static::where('category_id', $item->category_id)->count() + 1;
             $item->code = $prefix . str_pad($count, 3, '0', STR_PAD_LEFT);
         });

--- a/database/migrations/2025_08_09_115500_add_code_to_categories_table.php
+++ b/database/migrations/2025_08_09_115500_add_code_to_categories_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->string('code')->unique()->after('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->dropColumn('code');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,8 +15,8 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         // buat kategori default
-        $audio = Category::firstOrCreate(['name' => 'Audio']);
-        $video = Category::firstOrCreate(['name' => 'Video']);
+        $audio = Category::firstOrCreate(['code' => 'AUD'], ['name' => 'Audio']);
+        $video = Category::firstOrCreate(['code' => 'VID'], ['name' => 'Video']);
 
         // buat beberapa barang
         Item::firstOrCreate(

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -5,19 +5,22 @@
 <form action="{{ route('categories.store') }}" method="post" class="flex gap-2 bg-white p-4 rounded-2xl shadow mb-4">
     @csrf
     <input name="name" class="flex-1 border rounded p-2" placeholder="Nama kategori" required>
+    <input name="code" class="w-32 border rounded p-2" placeholder="Kode" required>
     <button class="px-4 py-2 rounded bg-slate-800 text-white">Simpan</button>
 </form>
 <div class="bg-white rounded-2xl shadow overflow-auto">
     <table class="w-full text-sm">
         <thead class="bg-slate-100">
             <tr>
-                <th class="p-2 text-left">Nama</th>
+                <th class="p-2 text-left">Nama Kategori</th>
+                <th class="p-2 text-left">Kode Kategori</th>
             </tr>
         </thead>
         <tbody>
             @foreach($categories as $c)
             <tr class="border-t">
                 <td class="p-2">{{ $c->name }}</td>
+                <td class="p-2">{{ $c->code }}</td>
             </tr>
             @endforeach
         </tbody>

--- a/resources/views/items/index.blade.php
+++ b/resources/views/items/index.blade.php
@@ -48,6 +48,8 @@
         <thead class="bg-slate-100">
             <tr>
                 <th class="p-2 text-left">Kode</th>
+                <th class="p-2 text-left">Nama Kategori</th>
+                <th class="p-2 text-left">Kode Kategori</th>
                 <th class="p-2 text-left">Serial</th>
                 <th class="p-2 text-left">Tahun</th>
                 <th class="p-2 text-left">Kondisi</th>
@@ -58,6 +60,8 @@
                 @foreach($it->assets as $as)
                 <tr class="border-t">
                     <td class="p-2">{{ $as->code }}</td>
+                    <td class="p-2">{{ $it->category->name }}</td>
+                    <td class="p-2">{{ $it->category->code }}</td>
                     <td class="p-2">{{ $as->serial_number }}</td>
                     <td class="p-2">{{ $as->procurement_year }}</td>
                     <td class="p-2">{{ str_replace('_',' ',$as->condition) }}</td>

--- a/tests/Feature/CategoryManagementTest.php
+++ b/tests/Feature/CategoryManagementTest.php
@@ -12,18 +12,19 @@ class CategoryManagementTest extends TestCase
 
     public function test_index_displays_categories(): void
     {
-        Category::create(['name' => 'Elektronik']);
+        Category::create(['name' => 'Elektronik','code' => 'ELK']);
 
         $response = $this->get('/categories');
         $response->assertStatus(200);
         $response->assertSee('Elektronik');
+        $response->assertSee('ELK');
     }
 
     public function test_store_creates_category(): void
     {
-        $response = $this->post('/categories', ['name' => 'Furniture']);
+        $response = $this->post('/categories', ['name' => 'Furniture','code' => 'FUR']);
 
         $response->assertRedirect('/categories');
-        $this->assertDatabaseHas('categories', ['name' => 'Furniture']);
+        $this->assertDatabaseHas('categories', ['name' => 'Furniture','code'=>'FUR']);
     }
 }

--- a/tests/Feature/ItemManagementTest.php
+++ b/tests/Feature/ItemManagementTest.php
@@ -12,7 +12,7 @@ class ItemManagementTest extends TestCase
 
     public function test_search_returns_stock_from_assets(): void
     {
-        $category = Category::create(['name' => 'Elektronik']);
+        $category = Category::create(['name' => 'Elektronik','code' => 'ELK']);
         $item = Item::create([
             'name' => 'Kamera',
             'details' => 'DSLR',
@@ -34,7 +34,7 @@ class ItemManagementTest extends TestCase
 
     public function test_store_creates_item_and_asset_with_generated_codes(): void
     {
-        $category = Category::create(['name' => 'Elektronik']);
+        $category = Category::create(['name' => 'Elektronik','code' => 'ELK']);
         $response = $this->post('/items', [
             'name' => 'Kamera',
             'details' => 'DSLR',
@@ -47,11 +47,31 @@ class ItemManagementTest extends TestCase
         $response->assertRedirect('/items');
         $this->assertDatabaseHas('items', [
             'name' => 'Kamera',
-            'code' => 'ELE001',
+            'code' => 'ELK001',
         ]);
         $this->assertDatabaseHas('assets', [
             'serial_number' => 'SN123',
-            'code' => 'ELE001-001',
+            'code' => 'ELK001-001',
         ]);
+    }
+
+    public function test_index_displays_category_name_and_code(): void
+    {
+        $category = Category::create(['name' => 'Elektronik','code' => 'ELK']);
+        $item = Item::create([
+            'name' => 'Kamera',
+            'details' => 'DSLR',
+            'category_id' => $category->id,
+        ]);
+        $item->assets()->create([
+            'serial_number' => 'SN123',
+            'procurement_year' => 2024,
+            'condition' => 'baik',
+        ]);
+
+        $response = $this->get('/items');
+        $response->assertStatus(200);
+        $response->assertSee('Elektronik');
+        $response->assertSee('ELK');
     }
 }


### PR DESCRIPTION
## Summary
- display category name and code on the item list
- label category table headers with explicit name and code columns

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68add93ad8d883259719369494ad7937