### PR TITLE
Fix categories table columns order

### DIFF
--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -12,16 +12,13 @@
     <table class="w-full text-sm">
         <thead class="bg-slate-100">
             <tr>
-
                 <th class="p-2 text-left">Nama Kategori</th>
                 <th class="p-2 text-left">Kode Kategori</th>
-
             </tr>
         </thead>
         <tbody>
             @foreach($categories as $c)
             <tr class="border-t">
-                <td class="p-2">{{ $c->code }}</td>
                 <td class="p-2">{{ $c->name }}</td>
                 <td class="p-2">{{ $c->code }}</td>
             </tr>


### PR DESCRIPTION
## Summary
- show category name and code only in categories table

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68adde63b8608325b4ab6a7ab22b1511