### PR TITLE
Replace barcode references with code

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,19 +20,17 @@ class DatabaseSeeder extends Seeder
 
         // buat beberapa barang
         Item::firstOrCreate(
-            ['barcode' => 'MIC-0001'],
+            ['code' => 'MIC-0001'],
             [
                 'name'        => 'Mic Shure SM58',
                 'category_id' => $audio->id,
-                'stock'       => 10,
             ],
         );
         Item::firstOrCreate(
-            ['barcode' => 'CAM-0101'],
+            ['code' => 'CAM-0101'],
             [
                 'name'        => 'Camera Sony XDCAM',
                 'category_id' => $video->id,
-                'stock'       => 3,
             ],
         );
 

--- a/resources/views/loans/create.blade.php
+++ b/resources/views/loans/create.blade.php
@@ -28,12 +28,12 @@
 
     <div class="grid md:grid-cols-2 gap-4">
         <div>
-            <label class="block text-sm">Scan Barcode / Cari Nama</label>
-            <input x-model="query" @keydown.enter.prevent="addByQuery()" class="w-full border rounded p-2" placeholder="Scan barcode atau ketik nama barang...">
+            <label class="block text-sm">Scan Kode / Cari Nama</label>
+            <input x-model="query" @keydown.enter.prevent="addByQuery()" class="w-full border rounded p-2" placeholder="Scan code atau ketik nama barang...">
             <div class="mt-2 bg-slate-50 border rounded max-h-48 overflow-auto" x-show="suggestions.length">
                 <template x-for="s in suggestions" :key="s.id">
                     <button type="button" @click="addItem(s)" class="w-full text-left px-3 py-2 hover:bg-white flex justify-between">
-                        <span x-text="`${s.barcode} — ${s.name}`"></span>
+                        <span x-text="`${s.code} — ${s.name}`"></span>
                         <span class="text-xs" x-text="`Stok: ${s.stock}`"></span>
                     </button>
                 </template>
@@ -51,7 +51,7 @@
         <table class="w-full text-sm border rounded">
             <thead class="bg-slate-100">
                 <tr>
-                    <th class="p-2 text-left">Barcode</th>
+                    <th class="p-2 text-left">Code</th>
                     <th class="p-2 text-left">Nama</th>
                     <th class="p-2 text-center">Jumlah</th>
                     <th class="p-2 text-center">Stok Tersisa</th>
@@ -61,7 +61,7 @@
             <tbody>
                 <template x-for="(row,idx) in items" :key="row.id">
                     <tr class="border-t">
-                        <td class="p-2" x-text="row.barcode"></td>
+                        <td class="p-2" x-text="row.code"></td>
                         <td class="p-2">
                             <span x-text="row.name"></span>
                             <template x-if="row.condition !== 'baik'">

--- a/resources/views/loans/return.blade.php
+++ b/resources/views/loans/return.blade.php
@@ -21,7 +21,7 @@
             @foreach($loan->items as $i => $li)
             @php $sisa = max(0,$li->qty - $li->returned_qty); @endphp
             <tr class="border-t">
-                <td class="p-2">{{ $li->item->barcode }} — {{ $li->item->name }}</td>
+                <td class="p-2">{{ $li->item->code }} — {{ $li->item->name }}</td>
                 <td class="p-2 text-center">{{ $li->qty }}</td>
                 <td class="p-2 text-center">{{ $li->returned_qty }}</td>
                 <td class="p-2 text-center">

--- a/resources/views/loans/show.blade.php
+++ b/resources/views/loans/show.blade.php
@@ -24,7 +24,7 @@
         <tbody>
             @foreach ($loan->items as $li)
             <tr class="border-t">
-                <td class="p-2">{{ $li->item->barcode }} — {{ $li->item->name }}</td>
+                <td class="p-2">{{ $li->item->code }} — {{ $li->item->name }}</td>
                 <td class="p-2 text-center">{{ $li->qty }}</td>
                 <td class="p-2 text-center">{{ $li->returned_qty }}</td>
                 <td class="p-2 text-center">{{ max(0, $li->qty - $li->returned_qty) }}</td>


### PR DESCRIPTION
## Summary
- Switch loan creation UI to use item `code` instead of `barcode`
- Display item code in loan detail and return pages
- Seed sample items by `code`

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68adde650a0c8325b8d95d63f89cf480