### PR TITLE
feat: add item code generation and display

### DIFF
--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -9,7 +9,7 @@ class ItemController extends Controller
 {
     public function index()
     {
-        $items = Item::latest()->paginate(10);
+        $items = Item::with('category')->latest()->paginate(10);
         $categories = Category::all();
         return view('items.index', compact('items', 'categories'));
     }
@@ -40,5 +40,19 @@ class ItemController extends Controller
             ->limit(10)
             ->get(['id', 'code', 'name']);
         return response()->json($items);
+    }
+
+    public function code(Request $r)
+    {
+        $data = $r->validate([
+            'category_id' => 'required|exists:categories,id',
+        ]);
+
+        $category = Category::find($data['category_id']);
+        $prefix = strtoupper($category->code_category);
+        $count = Item::where('category_id', $category->id)->count() + 1;
+        $code = $prefix . str_pad($count, 3, '0', STR_PAD_LEFT);
+
+        return response()->json(['code' => $code]);
     }
 }

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -26,7 +26,7 @@ class Item extends Model
     {
         static::creating(function (Item $item) {
             $category = Category::find($item->category_id);
-            $prefix = strtoupper(substr($category->name, 0, 3));
+            $prefix = strtoupper($category->code_category);
             $count = static::where('category_id', $item->category_id)->count() + 1;
             $item->code = $prefix . str_pad($count, 3, '0', STR_PAD_LEFT);
         });

--- a/resources/views/items/index.blade.php
+++ b/resources/views/items/index.blade.php
@@ -38,6 +38,10 @@
             @endforeach
         </select>
     </div>
+    <div class="md:col-span-2">
+        <label class="block text-sm">Kode Barang</label>
+        <input name="code" class="w-full border rounded p-2 bg-slate-100" readonly>
+    </div>
     <div class="md:col-span-2 text-right">
         <button class="px-4 py-2 rounded bg-slate-800 text-white">Simpan</button>
     </div>
@@ -48,6 +52,8 @@
         <thead class="bg-slate-100">
             <tr>
                 <th class="p-2 text-left">Kode</th>
+                <th class="p-2 text-left">Nama</th>
+                <th class="p-2 text-left">Kategori</th>
                 <th class="p-2 text-left">Serial</th>
                 <th class="p-2 text-left">Tahun</th>
                 <th class="p-2 text-left">Kondisi</th>
@@ -57,6 +63,8 @@
             @foreach($items as $it)
             <tr class="border-t">
                 <td class="p-2">{{ $it->code }}</td>
+                <td class="p-2">{{ $it->name }}</td>
+                <td class="p-2">{{ $it->category->name }}</td>
                 <td class="p-2">{{ $it->serial_number }}</td>
                 <td class="p-2">{{ $it->procurement_year }}</td>
                 <td class="p-2">{{ str_replace('_',' ',$it->condition) }}</td>
@@ -66,4 +74,17 @@
     </table>
 </div>
 <div class="mt-3">{{ $items->links() }}</div>
+<script>
+    document.querySelector('select[name="category_id"]').addEventListener('change', async function () {
+        const catId = this.value;
+        const codeInput = document.querySelector('input[name="code"]');
+        if (!catId) {
+            codeInput.value = '';
+            return;
+        }
+        const res = await fetch(`{{ route('items.code') }}?category_id=${catId}`);
+        const data = await res.json();
+        codeInput.value = data.code;
+    });
+</script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ Route::get('/', fn() => redirect()->route('loans.index'));
     Route::get('/items', [ItemController::class,'index'])->name('items.index');
     Route::post('/items', [ItemController::class,'store'])->name('items.store');
     Route::get('/items/search', [ItemController::class,'search'])->name('items.search'); // JSON
+    Route::get('/items/code', [ItemController::class,'code'])->name('items.code'); // JSON
 
     Route::get('/categories', [CategoryController::class,'index'])->name('categories.index');
     Route::post('/categories', [CategoryController::class,'store'])->name('categories.store');

--- a/tests/Feature/ItemManagementTest.php
+++ b/tests/Feature/ItemManagementTest.php
@@ -44,7 +44,7 @@ class ItemManagementTest extends TestCase
         $response->assertRedirect('/items');
         $this->assertDatabaseHas('items', [
             'name' => 'Kamera',
-            'code' => 'ELE001',
+            'code' => 'ELK001',
             'serial_number' => 'SN123',
         ]);
     }


### PR DESCRIPTION
## Summary
- generate item codes using category code prefixes
- show item code and category in item management view
- expose endpoint to fetch next item code

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b129e6541c83259e4531efc7ad15d4