### PR TITLE
Rename partner column and show officer

### DIFF
--- a/app/Http/Controllers/LoanController.php
+++ b/app/Http/Controllers/LoanController.php
@@ -10,7 +10,7 @@ use Illuminate\Validation\Rule;
 
 class LoanController extends Controller {
     public function index(){
-        $loans = Loan::with('partner','items.item')->latest()->paginate(15);
+        $loans = Loan::with('partner','items.item','user')->latest()->paginate(15);
         return view('loans.index', compact('loans'));
     }
 
@@ -50,12 +50,12 @@ class LoanController extends Controller {
     }
 
     public function show(Loan $loan){
-        $loan->load('partner','items.item');
+        $loan->load('partner','items.item','user');
         return view('loans.show', compact('loan'));
     }
 
     public function returnForm(Loan $loan){
-        $loan->load('items.item','partner');
+        $loan->load('items.item','partner','user');
         return view('loans.return', compact('loan'));
     }
 

--- a/app/Models/Loan.php
+++ b/app/Models/Loan.php
@@ -15,4 +15,5 @@ class Loan extends Model
     }
     public function partner(){ return $this->belongsTo(Partner::class); }
     public function items(){ return $this->hasMany(LoanItem::class); }
+    public function user(){ return $this->belongsTo(User::class); }
 }

--- a/resources/views/loans/create.blade.php
+++ b/resources/views/loans/create.blade.php
@@ -6,9 +6,9 @@
 <form action="{{ route('loans.store') }}" method="post" x-data="loanForm()" x-init="init()" class="grid gap-4 bg-white p-4 rounded-2xl shadow">
     @csrf
 
-    <div class="grid md:grid-cols-3 gap-4">
+    <div class="grid md:grid-cols-4 gap-4">
         <div>
-            <label class="block text-sm">Partner</label>
+            <label class="block text-sm">Nama Peminjam</label>
             <select name="partner_id" class="w-full border rounded p-2" required>
                 <option value="">-- Pilih --</option>
                 @foreach($partners as $p)
@@ -23,6 +23,10 @@
         <div>
             <label class="block text-sm">Tanggal Pinjam</label>
             <input type="datetime-local" name="loan_date" class="w-full border rounded p-2" value="{{ now()->format('Y-m-d\TH:i') }}" required>
+        </div>
+        <div>
+            <label class="block text-sm">Petugas</label>
+            <input value="{{ auth()->user()->name }}" class="w-full border rounded p-2" disabled>
         </div>
     </div>
 

--- a/resources/views/loans/index.blade.php
+++ b/resources/views/loans/index.blade.php
@@ -12,6 +12,7 @@
                 <th class="p-2 text-left">Nama Peminjam</th>
                 <th class="p-2 text-left">Keperluan Acara/Lokasi</th>
                 <th class="p-2 text-left">Tanggal Pinjam</th>
+                <th class="p-2 text-left">Petugas</th>
                 <th class="p-2 text-left">Status</th>
                 <th class="p-2"></th>
             </tr>
@@ -22,6 +23,7 @@
                 <td class="p-2">{{ $l->partner->name }}</td>
                 <td class="p-2">{{ $l->purpose }}</td>
                 <td class="p-2">{{ $l->loan_date }}</td>
+                <td class="p-2">{{ optional($l->user)->name }}</td>
                 <td class="p-2">
                     <span class="px-2 py-0.5 rounded-full text-xs"
         @class([

--- a/resources/views/loans/return.blade.php
+++ b/resources/views/loans/return.blade.php
@@ -2,7 +2,7 @@
 @extends('layouts.app')
 @section('content')
 <h1 class="text-xl font-semibold mb-2">Pengembalian — {{ $loan->code }}</h1>
-<p class="text-sm text-slate-600 mb-4">{{ $loan->partner->name }} • {{ $loan->purpose }}</p>
+<p class="text-sm text-slate-600 mb-4">{{ $loan->partner->name }} • {{ $loan->purpose }} • Petugas: {{ optional($loan->user)->name }}</p>
 
 <form action="{{ route('loans.return.process',$loan) }}" method="post" class="bg-white p-4 rounded-2xl shadow">
     @csrf

--- a/resources/views/loans/show.blade.php
+++ b/resources/views/loans/show.blade.php
@@ -4,7 +4,7 @@
 @section('content')
 <h1 class="text-xl font-semibold mb-2">Detail Peminjaman {{ $loan->code }}</h1>
 <p class="text-sm text-slate-600 mb-4">
-    {{ $loan->partner->name }} • {{ $loan->purpose }} • {{ $loan->loan_date }}
+    {{ $loan->partner->name }} • {{ $loan->purpose }} • {{ $loan->loan_date }} • Petugas: {{ optional($loan->user)->name }}
 </p>
 
 <a href="{{ route('loans.return.form', $loan) }}" class="px-3 py-2 rounded bg-slate-800 text-white">


### PR DESCRIPTION
## Summary
- Rename partner input to "Nama Peminjam" and show the logged-in officer on loan creation
- Display officer column on loan list and detail/return pages
- Add user relationship to Loan model and load it in controller

## Testing
- `php artisan test` *(fails: file_get_contents(/workspace/broadcast-loan/.env): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68b1476736e08325aa91931799b3897f