### PR TITLE
Align views with Laravel Breeze layout

### DIFF
--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -1,31 +1,38 @@
 <!-- resources/views/categories/index.blade.php -->
-@extends('layouts.app')
-@section('content')
-<h1 class="text-xl font-semibold mb-4">Kategori Barang</h1>
-<form action="{{ route('categories.store') }}" method="post" class="flex gap-2 bg-white p-4 rounded-2xl shadow mb-4">
-    @csrf
-    <input name="name" class="flex-1 border rounded p-2" placeholder="Nama kategori" required>
-    <input name="code_category" class="flex-1 border rounded p-2" placeholder="Kode Kategori" required>
-    <button class="px-4 py-2 rounded bg-slate-800 text-white">Simpan</button>
-</form>
-<div class="bg-white rounded-2xl shadow overflow-auto">
-    <table class="w-full text-sm">
-        <thead class="bg-slate-100">
-            <tr>
-                <th class="p-2 text-left">Nama</th>
-                <th class="p-2 text-left">Kode</th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach($categories as $c)
-            <tr class="border-t">
-                <td class="p-2">{{ $c->name }}</td>
-                <td class="p-2">{{ $c->code_category }}</td>
-            </tr>
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Kategori Barang') }}
+        </h2>
+    </x-slot>
 
-            @endforeach
-        </tbody>
-    </table>
-</div>
-<div class="mt-3">{{ $categories->links() }}</div>
-@endsection
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <form action="{{ route('categories.store') }}" method="post" class="flex gap-2 bg-white p-4 rounded-2xl shadow mb-4">
+                @csrf
+                <input name="name" class="flex-1 border rounded p-2" placeholder="Nama kategori" required>
+                <input name="code_category" class="flex-1 border rounded p-2" placeholder="Kode Kategori" required>
+                <button class="px-4 py-2 rounded bg-slate-800 text-white">Simpan</button>
+            </form>
+            <div class="bg-white rounded-2xl shadow overflow-auto">
+                <table class="w-full text-sm">
+                    <thead class="bg-slate-100">
+                        <tr>
+                            <th class="p-2 text-left">Nama</th>
+                            <th class="p-2 text-left">Kode</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($categories as $c)
+                        <tr class="border-t">
+                            <td class="p-2">{{ $c->name }}</td>
+                            <td class="p-2">{{ $c->code_category }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+            <div class="mt-3">{{ $categories->links() }}</div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/items/index.blade.php
+++ b/resources/views/items/index.blade.php
@@ -1,90 +1,97 @@
 <!-- resources/views/items/index.blade.php -->
-@extends('layouts.app')
-@section('content')
-<h1 class="text-xl font-semibold mb-4">Master Aset Barang</h1>
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Master Aset Barang') }}
+        </h2>
+    </x-slot>
 
-<form action="{{ route('items.store') }}" method="post" class="grid md:grid-cols-2 gap-4 bg-white p-4 rounded-2xl shadow mb-4">
-    @csrf
-    <div class="md:col-span-2">
-        <label class="block text-sm">Nama Barang</label>
-        <input name="name" class="w-full border rounded p-2" required>
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <form action="{{ route('items.store') }}" method="post" class="grid md:grid-cols-2 gap-4 bg-white p-4 rounded-2xl shadow mb-4">
+                @csrf
+                <div class="md:col-span-2">
+                    <label class="block text-sm">Nama Barang</label>
+                    <input name="name" class="w-full border rounded p-2" required>
+                </div>
+                <div class="md:col-span-2">
+                    <label class="block text-sm">Detail Barang</label>
+                    <textarea name="details" class="w-full border rounded p-2"></textarea>
+                </div>
+                <div>
+                    <label class="block text-sm">Serial Number</label>
+                    <input name="serial_number" class="w-full border rounded p-2">
+                </div>
+                <div>
+                    <label class="block text-sm">Tahun Pengadaan</label>
+                    <input type="number" name="procurement_year" class="w-full border rounded p-2" value="{{ now()->year }}">
+                </div>
+                <div>
+                    <label class="block text-sm">Kondisi</label>
+                    <select name="condition" class="w-full border rounded p-2" required>
+                        <option value="baik">baik</option>
+                        <option value="rusak_ringan">rusak ringan</option>
+                        <option value="rusak_berat">rusak berat</option>
+                    </select>
+                </div>
+                <div class="md:col-span-2">
+                    <label class="block text-sm">Kategori</label>
+                    <select name="category_id" class="w-full border rounded p-2" required>
+                        <option value="">-- Pilih --</option>
+                        @foreach($categories as $c)
+                        <option value="{{ $c->id }}">{{ $c->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="md:col-span-2">
+                    <label class="block text-sm">Kode Barang</label>
+                    <input name="code" class="w-full border rounded p-2 bg-slate-100" readonly>
+                </div>
+                <div class="md:col-span-2 text-right">
+                    <button class="px-4 py-2 rounded bg-slate-800 text-white">Simpan</button>
+                </div>
+            </form>
+            <div class="bg-white rounded-2xl shadow overflow-auto">
+                <table class="w-full text-sm">
+                    <thead class="bg-slate-100">
+                        <tr>
+                            <th class="p-2 text-left">Kode</th>
+                            <th class="p-2 text-left">Nama</th>
+                            <th class="p-2 text-left">Kategori</th>
+                            <th class="p-2 text-left">Serial</th>
+                            <th class="p-2 text-left">Tahun</th>
+                            <th class="p-2 text-left">Kondisi</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($items as $it)
+                        <tr class="border-t">
+                            <td class="p-2">{{ $it->code }}</td>
+                            <td class="p-2">{{ $it->name }}</td>
+                            <td class="p-2">{{ $it->category->name }}</td>
+                            <td class="p-2">{{ $it->serial_number }}</td>
+                            <td class="p-2">{{ $it->procurement_year }}</td>
+                            <td class="p-2">{{ str_replace('_',' ',$it->condition) }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+            <div class="mt-3">{{ $items->links() }}</div>
+        </div>
     </div>
-    <div class="md:col-span-2">
-        <label class="block text-sm">Detail Barang</label>
-        <textarea name="details" class="w-full border rounded p-2"></textarea>
-    </div>
-    <div>
-        <label class="block text-sm">Serial Number</label>
-        <input name="serial_number" class="w-full border rounded p-2">
-    </div>
-    <div>
-        <label class="block text-sm">Tahun Pengadaan</label>
-        <input type="number" name="procurement_year" class="w-full border rounded p-2" value="{{ now()->year }}">
-    </div>
-    <div>
-        <label class="block text-sm">Kondisi</label>
-        <select name="condition" class="w-full border rounded p-2" required>
-            <option value="baik">baik</option>
-            <option value="rusak_ringan">rusak ringan</option>
-            <option value="rusak_berat">rusak berat</option>
-        </select>
-    </div>
-    <div class="md:col-span-2">
-        <label class="block text-sm">Kategori</label>
-        <select name="category_id" class="w-full border rounded p-2" required>
-            <option value="">-- Pilih --</option>
-            @foreach($categories as $c)
-            <option value="{{ $c->id }}">{{ $c->name }}</option>
-            @endforeach
-        </select>
-    </div>
-    <div class="md:col-span-2">
-        <label class="block text-sm">Kode Barang</label>
-        <input name="code" class="w-full border rounded p-2 bg-slate-100" readonly>
-    </div>
-    <div class="md:col-span-2 text-right">
-        <button class="px-4 py-2 rounded bg-slate-800 text-white">Simpan</button>
-    </div>
-</form>
 
-<div class="bg-white rounded-2xl shadow overflow-auto">
-    <table class="w-full text-sm">
-        <thead class="bg-slate-100">
-            <tr>
-                <th class="p-2 text-left">Kode</th>
-                <th class="p-2 text-left">Nama</th>
-                <th class="p-2 text-left">Kategori</th>
-                <th class="p-2 text-left">Serial</th>
-                <th class="p-2 text-left">Tahun</th>
-                <th class="p-2 text-left">Kondisi</th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach($items as $it)
-            <tr class="border-t">
-                <td class="p-2">{{ $it->code }}</td>
-                <td class="p-2">{{ $it->name }}</td>
-                <td class="p-2">{{ $it->category->name }}</td>
-                <td class="p-2">{{ $it->serial_number }}</td>
-                <td class="p-2">{{ $it->procurement_year }}</td>
-                <td class="p-2">{{ str_replace('_',' ',$it->condition) }}</td>
-            </tr>
-            @endforeach
-        </tbody>
-    </table>
-</div>
-<div class="mt-3">{{ $items->links() }}</div>
-<script>
-    document.querySelector('select[name="category_id"]').addEventListener('change', async function () {
-        const catId = this.value;
-        const codeInput = document.querySelector('input[name="code"]');
-        if (!catId) {
-            codeInput.value = '';
-            return;
-        }
-        const res = await fetch(`{{ route('items.code') }}?category_id=${catId}`);
-        const data = await res.json();
-        codeInput.value = data.code;
-    });
-</script>
-@endsection
+    <script>
+        document.querySelector('select[name="category_id"]').addEventListener('change', async function () {
+            const catId = this.value;
+            const codeInput = document.querySelector('input[name="code"]');
+            if (!catId) {
+                codeInput.value = '';
+                return;
+            }
+            const res = await fetch(`{{ route('items.code') }}?category_id=${catId}`);
+            const data = await res.json();
+            codeInput.value = data.code;
+        });
+    </script>
+</x-app-layout>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -29,8 +29,7 @@
 
             <!-- Page Content -->
             <main>
-                {{ $slot ?? '' }}
-                @yield('content')
+                {{ $slot }}
             </main>
         </div>
     </body>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -15,6 +15,15 @@
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('loans.index')" :active="request()->routeIs('loans.*')">
+                        {{ __('Peminjaman') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('items.index')" :active="request()->routeIs('items.*')">
+                        {{ __('Barang') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('categories.index')" :active="request()->routeIs('categories.*')">
+                        {{ __('Kategori') }}
+                    </x-nav-link>
                 </div>
             </div>
 
@@ -69,6 +78,15 @@
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                 {{ __('Dashboard') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('loans.index')" :active="request()->routeIs('loans.*')">
+                {{ __('Peminjaman') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('items.index')" :active="request()->routeIs('items.*')">
+                {{ __('Barang') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('categories.index')" :active="request()->routeIs('categories.*')">
+                {{ __('Kategori') }}
             </x-responsive-nav-link>
         </div>
 

--- a/resources/views/loans/create.blade.php
+++ b/resources/views/loans/create.blade.php
@@ -1,12 +1,17 @@
 <!-- resources/views/loans/create.blade.php -->
-@extends('layouts.app')
-@section('content')
-<h1 class="text-xl font-semibold mb-4">Buat Peminjaman</h1>
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Buat Peminjaman') }}
+        </h2>
+    </x-slot>
 
-<form action="{{ route('loans.store') }}" method="post" x-data="loanForm()" x-init="init()" class="grid gap-4 bg-white p-4 rounded-2xl shadow">
-    @csrf
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <form action="{{ route('loans.store') }}" method="post" x-data="loanForm()" x-init="init()" class="grid gap-4 bg-white p-4 rounded-2xl shadow">
+                @csrf
 
-    <div class="grid md:grid-cols-4 gap-4">
+                <div class="grid md:grid-cols-4 gap-4">
         <div>
             <label class="block text-sm">Nama Peminjam</label>
             <select name="partner_id" class="w-full border rounded p-2" required>
@@ -112,8 +117,10 @@
         <button class="px-4 py-2 rounded bg-slate-800 text-white">Simpan Peminjaman</button>
     </div>
 </form>
+        </div>
+    </div>
 
-<script>
+    <script>
     function loanForm(){
   return {
     query: '', items: [], suggestions: [],
@@ -147,5 +154,5 @@
     }
   }
 }
-</script>
-@endsection
+    </script>
+</x-app-layout>

--- a/resources/views/loans/index.blade.php
+++ b/resources/views/loans/index.blade.php
@@ -1,44 +1,53 @@
 <!-- resources/views/loans/index.blade.php -->
-@extends('layouts.app')
-@section('content')
-<div class="flex justify-between items-center mb-4">
-    <h1 class="text-xl font-semibold">Daftar Peminjaman</h1>
-    <a href="{{ route('loans.create') }}" class="px-3 py-2 rounded bg-slate-800 text-white">Buat Peminjaman</a>
-</div>
-<div class="bg-white rounded-2xl shadow overflow-hidden">
-    <table class="w-full text-sm">
-        <thead class="bg-slate-100">
-            <tr>
-                <th class="p-2 text-left">Nama Peminjam</th>
-                <th class="p-2 text-left">Keperluan Acara/Lokasi</th>
-                <th class="p-2 text-left">Tanggal Pinjam</th>
-                <th class="p-2 text-left">Petugas</th>
-                <th class="p-2 text-left">Status</th>
-                <th class="p-2"></th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach($loans as $l)
-            <tr class="border-t">
-                <td class="p-2">{{ $l->partner->name }}</td>
-                <td class="p-2">{{ $l->purpose }}</td>
-                <td class="p-2">{{ $l->loan_date }}</td>
-                <td class="p-2">{{ optional($l->user)->name }}</td>
-                <td class="p-2">
-                    <span class="px-2 py-0.5 rounded-full text-xs"
-        @class([
-            'bg-amber-100 text-amber-700' => $l->status==='dipinjam',
-            'bg-sky-100 text-sky-700' => $l->status==='sebagian_kembali',
-            'bg-emerald-100 text-emerald-700' => $l->status==='selesai',
-        ])>{{ str_replace('_',' ',$l->status) }}</span>
-                </td>
-                <td class="p-2 text-right">
-                    <a href="{{ route('loans.show',$l) }}" class="px-2 py-1 rounded bg-slate-800 text-white">Detail</a>
-                </td>
-            </tr>
-            @endforeach
-        </tbody>
-    </table>
-</div>
-<div class="mt-3">{{ $loans->links() }}</div>
-@endsection
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Daftar Peminjaman') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center mb-4">
+                <div></div>
+                <a href="{{ route('loans.create') }}" class="px-3 py-2 rounded bg-slate-800 text-white">Buat Peminjaman</a>
+            </div>
+            <div class="bg-white rounded-2xl shadow overflow-hidden">
+                <table class="w-full text-sm">
+                    <thead class="bg-slate-100">
+                        <tr>
+                            <th class="p-2 text-left">Nama Peminjam</th>
+                            <th class="p-2 text-left">Keperluan Acara/Lokasi</th>
+                            <th class="p-2 text-left">Tanggal Pinjam</th>
+                            <th class="p-2 text-left">Petugas</th>
+                            <th class="p-2 text-left">Status</th>
+                            <th class="p-2"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($loans as $l)
+                        <tr class="border-t">
+                            <td class="p-2">{{ $l->partner->name }}</td>
+                            <td class="p-2">{{ $l->purpose }}</td>
+                            <td class="p-2">{{ $l->loan_date }}</td>
+                            <td class="p-2">{{ optional($l->user)->name }}</td>
+                            <td class="p-2">
+                                <span class="px-2 py-0.5 rounded-full text-xs"
+                @class([
+                    'bg-amber-100 text-amber-700' => $l->status==='dipinjam',
+                    'bg-sky-100 text-sky-700' => $l->status==='sebagian_kembali',
+                    'bg-emerald-100 text-emerald-700' => $l->status==='selesai',
+                ])>{{ str_replace('_',' ',$l->status) }}</span>
+                            </td>
+                            <td class="p-2 text-right">
+                                <a href="{{ route('loans.show',$l) }}" class="px-2 py-1 rounded bg-slate-800 text-white">Detail</a>
+                            </td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+            <div class="mt-3">{{ $loans->links() }}</div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/loans/return.blade.php
+++ b/resources/views/loans/return.blade.php
@@ -1,49 +1,56 @@
 <!-- resources/views/loans/return.blade.php -->
-@extends('layouts.app')
-@section('content')
-<h1 class="text-xl font-semibold mb-2">Pengembalian — {{ $loan->code }}</h1>
-<p class="text-sm text-slate-600 mb-4">{{ $loan->partner->name }} • {{ $loan->purpose }} • Petugas: {{ optional($loan->user)->name }}</p>
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Pengembalian') }} — {{ $loan->code }}
+        </h2>
+    </x-slot>
 
-<form action="{{ route('loans.return.process',$loan) }}" method="post" class="bg-white p-4 rounded-2xl shadow">
-    @csrf
-    <table class="w-full text-sm">
-        <thead class="bg-slate-100">
-            <tr>
-                <th class="p-2 text-left">Barang</th>
-                <th class="p-2 text-center">Dipinjam</th>
-                <th class="p-2 text-center">Sudah Kembali</th>
-                <th class="p-2 text-center">Kembalikan</th>
-                <th class="p-2 text-center">Kondisi</th>
-                <th class="p-2">Catatan</th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach($loan->items as $i => $li)
-            @php $sisa = max(0,$li->qty - $li->returned_qty); @endphp
-            <tr class="border-t">
-                <td class="p-2">{{ $li->item->code }} — {{ $li->item->name }}</td>
-                <td class="p-2 text-center">{{ $li->qty }}</td>
-                <td class="p-2 text-center">{{ $li->returned_qty }}</td>
-                <td class="p-2 text-center">
-                    <input type="number" name="returns[{{ $i }}][qty]" min="0" max="{{ $sisa }}" value="{{ $sisa }}" class="w-20 border rounded p-1 text-center">
-                    <input type="hidden" name="returns[{{ $i }}][loan_item_id]" value="{{ $li->id }}">
-                </td>
-                <td class="p-2 text-center">
-                    <select name="returns[{{ $i }}][condition]" class="border rounded p-1">
-                        <option value="baik">Baik</option>
-                        <option value="rusak_ringan">Rusak ringan</option>
-                        <option value="rusak_berat">Rusak berat</option>
-                    </select>
-                </td>
-                <td class="p-2">
-                    <input name="returns[{{ $i }}][notes]" class="w-full border rounded p-1" placeholder="Catatan (opsional)">
-                </td>
-            </tr>
-            @endforeach
-        </tbody>
-    </table>
-    <div class="text-right mt-4">
-        <button class="px-4 py-2 rounded bg-slate-800 text-white">Simpan Pengembalian</button>
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <p class="text-sm text-slate-600 mb-4">{{ $loan->partner->name }} • {{ $loan->purpose }} • Petugas: {{ optional($loan->user)->name }}</p>
+            <form action="{{ route('loans.return.process',$loan) }}" method="post" class="bg-white p-4 rounded-2xl shadow">
+                @csrf
+                <table class="w-full text-sm">
+                    <thead class="bg-slate-100">
+                        <tr>
+                            <th class="p-2 text-left">Barang</th>
+                            <th class="p-2 text-center">Dipinjam</th>
+                            <th class="p-2 text-center">Sudah Kembali</th>
+                            <th class="p-2 text-center">Kembalikan</th>
+                            <th class="p-2 text-center">Kondisi</th>
+                            <th class="p-2">Catatan</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($loan->items as $i => $li)
+                        @php $sisa = max(0,$li->qty - $li->returned_qty); @endphp
+                        <tr class="border-t">
+                            <td class="p-2">{{ $li->item->code }} — {{ $li->item->name }}</td>
+                            <td class="p-2 text-center">{{ $li->qty }}</td>
+                            <td class="p-2 text-center">{{ $li->returned_qty }}</td>
+                            <td class="p-2 text-center">
+                                <input type="number" name="returns[{{ $i }}][qty]" min="0" max="{{ $sisa }}" value="{{ $sisa }}" class="w-20 border rounded p-1 text-center">
+                                <input type="hidden" name="returns[{{ $i }}][loan_item_id]" value="{{ $li->id }}">
+                            </td>
+                            <td class="p-2 text-center">
+                                <select name="returns[{{ $i }}][condition]" class="border rounded p-1">
+                                    <option value="baik">Baik</option>
+                                    <option value="rusak_ringan">Rusak ringan</option>
+                                    <option value="rusak_berat">Rusak berat</option>
+                                </select>
+                            </td>
+                            <td class="p-2">
+                                <input name="returns[{{ $i }}][notes]" class="w-full border rounded p-1" placeholder="Catatan (opsional)">
+                            </td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+                <div class="text-right mt-4">
+                    <button class="px-4 py-2 rounded bg-slate-800 text-white">Simpan Pengembalian</button>
+                </div>
+            </form>
+        </div>
     </div>
-</form>
-@endsection
+</x-app-layout>

--- a/resources/views/loans/show.blade.php
+++ b/resources/views/loans/show.blade.php
@@ -1,36 +1,41 @@
 {{-- resources/views/loans/show.blade.php --}}
-@extends('layouts.app')
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Detail Peminjaman') }} {{ $loan->code }}
+        </h2>
+    </x-slot>
 
-@section('content')
-<h1 class="text-xl font-semibold mb-2">Detail Peminjaman {{ $loan->code }}</h1>
-<p class="text-sm text-slate-600 mb-4">
-    {{ $loan->partner->name }} • {{ $loan->purpose }} • {{ $loan->loan_date }} • Petugas: {{ optional($loan->user)->name }}
-</p>
-
-<a href="{{ route('loans.return.form', $loan) }}" class="px-3 py-2 rounded bg-slate-800 text-white">
-    Proses Pengembalian
-</a>
-
-<div class="mt-4 bg-white rounded-2xl shadow overflow-hidden">
-    <table class="w-full text-sm">
-        <thead class="bg-slate-100">
-            <tr>
-                <th class="p-2">Barang</th>
-                <th class="p-2 text-center">Qty</th>
-                <th class="p-2 text-center">Kembali</th>
-                <th class="p-2 text-center">Sisa</th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach ($loan->items as $li)
-            <tr class="border-t">
-                <td class="p-2">{{ $li->item->code }} — {{ $li->item->name }}</td>
-                <td class="p-2 text-center">{{ $li->qty }}</td>
-                <td class="p-2 text-center">{{ $li->returned_qty }}</td>
-                <td class="p-2 text-center">{{ max(0, $li->qty - $li->returned_qty) }}</td>
-            </tr>
-            @endforeach
-        </tbody>
-    </table>
-</div>
-@endsection
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <p class="text-sm text-slate-600 mb-4">
+                {{ $loan->partner->name }} • {{ $loan->purpose }} • {{ $loan->loan_date }} • Petugas: {{ optional($loan->user)->name }}
+            </p>
+            <a href="{{ route('loans.return.form', $loan) }}" class="px-3 py-2 rounded bg-slate-800 text-white">
+                Proses Pengembalian
+            </a>
+            <div class="mt-4 bg-white rounded-2xl shadow overflow-hidden">
+                <table class="w-full text-sm">
+                    <thead class="bg-slate-100">
+                        <tr>
+                            <th class="p-2">Barang</th>
+                            <th class="p-2 text-center">Qty</th>
+                            <th class="p-2 text-center">Kembali</th>
+                            <th class="p-2 text-center">Sisa</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($loan->items as $li)
+                        <tr class="border-t">
+                            <td class="p-2">{{ $li->item->code }} — {{ $li->item->name }}</td>
+                            <td class="p-2 text-center">{{ $li->qty }}</td>
+                            <td class="p-2 text-center">{{ $li->returned_qty }}</td>
+                            <td class="p-2 text-center">{{ max(0, $li->qty - $li->returned_qty) }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</x-app-layout>


### PR DESCRIPTION
## Summary
- replace `@extends('layouts.app')` usage with `<x-app-layout>` across category, item, and loan pages
- remove `@yield('content')` from the main layout and rely solely on slot-based Breeze layout
- wrap page content in standard Breeze container structure
- add navigation links for loans, items, and categories in the layout

## Testing
- `composer test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1517f3d308325a4d2400472b814b6