### PR TITLE
Add serial number and condition columns for loans

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -20,8 +20,11 @@ class CategoryController extends Controller
             'code_category'=>'required'
         ]);
 
-        Category::create($data);
-
-        return redirect()->route('categories.index')->with('ok', 'Kategori berhasil disimpan');
+        try {
+            Category::create($data);
+            return redirect()->route('categories.index')->with('ok', 'Kategori berhasil disimpan');
+        } catch (\Throwable $e) {
+            return back()->with('error', 'Kategori gagal disimpan.')->withInput();
+        }
     }
 }

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -25,9 +25,12 @@ class ItemController extends Controller
             'condition' => 'required|in:baik,rusak_ringan,rusak_berat',
         ]);
 
-        Item::create($data);
-
-        return redirect()->route('items.index')->with('ok', 'Barang berhasil disimpan');
+        try {
+            Item::create($data);
+            return redirect()->route('items.index')->with('ok', 'Barang berhasil disimpan');
+        } catch (\Throwable $e) {
+            return back()->with('error', 'Barang gagal disimpan.')->withInput();
+        }
     }
 
     public function search(Request $r)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
                 "@tailwindcss/forms": "^0.5.2",
                 "@tailwindcss/vite": "^4.0.0",
                 "alpinejs": "^3.4.2",
-                "autoprefixer": "^10.4.2",
+                "autoprefixer": "^10.4.21",
                 "axios": "^1.11.0",
                 "concurrently": "^9.0.1",
                 "laravel-vite-plugin": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/vite": "^4.0.0",
         "alpinejs": "^3.4.2",
-        "autoprefixer": "^10.4.2",
+        "autoprefixer": "^10.4.21",
         "axios": "^1.11.0",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^2.0.0",

--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -1,0 +1,24 @@
+@props(['type' => 'success', 'message'])
+
+@php
+    $styles = [
+        'success' => 'bg-green-50 border-green-400 text-green-800',
+        'error'   => 'bg-red-50 border-red-400 text-red-800',
+    ];
+    $paths = [
+        'success' => 'M5 13l4 4L19 7',
+        'error'   => 'M6 18L18 6M6 6l12 12',
+    ];
+@endphp
+
+<div x-data="{show: true}" x-show="show" x-transition class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-4">
+    <div class="flex items-start justify-between p-4 border-l-4 rounded shadow-sm {{ $styles[$type] ?? $styles['success'] }}">
+        <div class="flex items-center space-x-2">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" d="{{ $paths[$type] ?? $paths['success'] }}" />
+            </svg>
+            <span>{{ $message }}</span>
+        </div>
+        <button @click="show=false" class="ml-4 text-xl leading-none focus:outline-none">&times;</button>
+    </div>
+</div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -27,6 +27,12 @@
                 </header>
             @endisset
 
+            @if (session('ok'))
+                <x-alert type="success" :message="session('ok')" />
+            @elseif (session('error'))
+                <x-alert type="error" :message="session('error')" />
+            @endif
+
             <!-- Page Content -->
             <main>
                 {{ $slot }}

--- a/resources/views/loans/create.blade.php
+++ b/resources/views/loans/create.blade.php
@@ -74,7 +74,8 @@
                             <tr>
                                 <th class="p-2 text-left">Kode</th>
                                 <th class="p-2 text-left">Nama</th>
-                                <th class="p-2 text-center">Jumlah</th>
+                                <th class="p-2 text-left">Serial Number</th>
+                                <th class="p-2 text-center">Kondisi</th>
                                 <th class="p-2"></th>
                             </tr>
                         </thead>
@@ -82,14 +83,12 @@
                             <template x-for="(row,idx) in items" :key="row.id">
                                 <tr class="border-t">
                                     <td class="p-2" x-text="row.code"></td>
-                                    <td class="p-2">
-                                        <span x-text="row.name"></span>
-                                        <template x-if="row.condition !== 'baik'">
-                                            <span class="ml-2 px-2 py-0.5 text-xs rounded-full" :class="row.condition==='rusak_berat' ? 'bg-red-100 text-red-700' : 'bg-amber-100 text-amber-700' " x-text="row.condition.replace('_',' ')"></span>
-                                        </template>
-                                    </td>
+                                    <td class="p-2" x-text="row.name"></td>
+                                    <td class="p-2" x-text="row.serial_number ?? '-'" ></td>
                                     <td class="p-2 text-center">
-                                        <input type="number" min="1" class="w-20 border rounded p-1 text-center" x-model.number="row.qty">
+                                        <span class="px-2 py-0.5 text-xs rounded-full"
+                                            :class="row.condition==='rusak_berat' ? 'bg-red-100 text-red-700' : (row.condition==='rusak_ringan' ? 'bg-amber-100 text-amber-700' : 'bg-emerald-100 text-emerald-700')"
+                                            x-text="row.condition.replace('_',' ')"></span>
                                         <input type="hidden" :name="`items[${idx}][id]`" :value="row.id">
                                         <input type="hidden" :name="`items[${idx}][qty]`" :value="row.qty">
                                     </td>
@@ -124,8 +123,8 @@
     },
     addItem(it){
       const exist = this.items.find(x=>x.id===it.id);
-      if(exist){ exist.qty++; }
-      else { this.items.push({...it, qty: 1}); }
+      if(exist) return;
+      this.items.push({...it, qty: 1});
       this.query=''; this.suggestions=[];
     },
     addByQuery(){

--- a/resources/views/loans/show.blade.php
+++ b/resources/views/loans/show.blade.php
@@ -19,7 +19,8 @@
                     <thead class="bg-slate-100">
                         <tr>
                             <th class="p-2">Barang</th>
-                            <th class="p-2 text-center">Qty</th>
+                            <th class="p-2">Serial Number</th>
+                            <th class="p-2 text-center">Kondisi</th>
                             <th class="p-2 text-center">Kembali</th>
                             <th class="p-2 text-center">Sisa</th>
                         </tr>
@@ -28,7 +29,15 @@
                         @foreach ($loan->items as $li)
                         <tr class="border-t">
                             <td class="p-2">{{ $li->item->code }} — {{ $li->item->name }}</td>
-                            <td class="p-2 text-center">{{ $li->qty }}</td>
+                            <td class="p-2">{{ $li->item->serial_number }}</td>
+                            <td class="p-2 text-center">
+                                <span class="px-2 py-0.5 text-xs rounded-full"
+                                    @class([
+                                        'bg-emerald-100 text-emerald-700' => $li->item->condition==='baik',
+                                        'bg-amber-100 text-amber-700' => $li->item->condition==='rusak_ringan',
+                                        'bg-red-100 text-red-700' => $li->item->condition==='rusak_berat',
+                                    ])>{{ str_replace('_',' ',$li->item->condition) }}</span>
+                            </td>
                             <td class="p-2 text-center">{{ $li->returned_qty }}</td>
                             <td class="p-2 text-center">{{ max(0, $li->qty - $li->returned_qty) }}</td>
                         </tr>


### PR DESCRIPTION
## Summary
- show serial number and item condition on loan detail and creation tables
- remove adjustable quantity column from loan creation UI
- display responsive alerts for success and failure across item, category, and loan actions

## Testing
- `npm run build`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68b15c154d2083258d053d6459303c41