### PR TITLE
Allow manual borrower name entry on loan creation

### DIFF
--- a/app/Http/Controllers/LoanController.php
+++ b/app/Http/Controllers/LoanController.php
@@ -15,14 +15,12 @@ class LoanController extends Controller {
     }
 
     public function create(){
-        return view('loans.create', [
-            'partners'=>Partner::orderBy('name')->get()
-        ]);
+        return view('loans.create');
     }
 
     public function store(Request $r){
         $data = $r->validate([
-            'partner_id' => ['required','exists:partners,id'],
+            'partner_name' => ['required','string','max:255'],
             'purpose'    => ['required','string','max:255'],
             'loan_date'  => ['required','date'],
             'items'      => ['required','array','min:1'],
@@ -31,9 +29,11 @@ class LoanController extends Controller {
         ]);
 
         try {
-            DB::transaction(function() use ($data){
+            $partner = Partner::firstOrCreate(['name'=>$data['partner_name']]);
+
+            DB::transaction(function() use ($data, $partner){
                 $loan = Loan::create([
-                    'partner_id'=>$data['partner_id'],
+                    'partner_id'=>$partner->id,
                     'purpose'=>$data['purpose'],
                     'loan_date'=>$data['loan_date'],
                     'user_id'=>auth()->id()

--- a/resources/views/loans/create.blade.php
+++ b/resources/views/loans/create.blade.php
@@ -14,7 +14,7 @@
                 <div class="grid md:grid-cols-4 gap-4">
                     <div>
                         <label class="block text-sm">Nama Peminjam</label>
-                        <input name="partner_id" class="w-full border rounded p-2" placeholder="" required>
+                        <input name="partner_name" class="w-full border rounded p-2" placeholder="Nama Peminjam" value="{{ old('partner_name') }}" required>
                     </div>
                     <div>
                         <label class="block text-sm">Keperluan / Lokasi</label>


### PR DESCRIPTION
## Summary
- change borrower field to free text input on loan creation form
- auto-create or reuse partner by name when storing a loan

## Testing
- `composer test` (fails: Vite manifest not found)

------
https://chatgpt.com/codex/tasks/task_e_68b1619a1e0883259d82433c38ff35ba